### PR TITLE
Add simple GUI to control MurMur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # MurMur
 MurMur is a silent local agent that detects and auto-fixes common technical issues like Wi-Fi drops or frozen processes. Modular, real-time, and fully automated — it works quietly in the background to keep your system smooth without interruptions.
+
+## GUI Front-end
+
+A basic Tkinter interface is provided in `gui.py`.
+Run it with:
+
+```bash
+python gui.py
+```
+
+It will let you start or stop MurMur from a small window.

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,51 @@
+import tkinter as tk
+from tkinter import messagebox
+import subprocess
+import sys
+
+class MurMurGUI:
+    def __init__(self, master):
+        self.master = master
+        master.title("MurMur GUI")
+        self.process = None
+
+        self.status_var = tk.StringVar(value="Stopped")
+        tk.Label(master, text="MurMur status:").pack(pady=(10,0))
+        self.status_label = tk.Label(master, textvariable=self.status_var, fg="green")
+        self.status_label.pack(pady=5)
+
+        self.start_button = tk.Button(master, text="Start", command=self.start_murmur)
+        self.start_button.pack(pady=5)
+
+        self.stop_button = tk.Button(master, text="Stop", command=self.stop_murmur, state=tk.DISABLED)
+        self.stop_button.pack(pady=5)
+
+    def start_murmur(self):
+        if self.process is None:
+            self.process = subprocess.Popen([sys.executable, "main.py"])
+            self.status_var.set("Running")
+            self.start_button.config(state=tk.DISABLED)
+            self.stop_button.config(state=tk.NORMAL)
+
+    def stop_murmur(self):
+        if self.process is not None:
+            self.process.terminate()
+            self.process = None
+            self.status_var.set("Stopped")
+            self.start_button.config(state=tk.NORMAL)
+            self.stop_button.config(state=tk.DISABLED)
+
+    def on_close(self):
+        if self.process is not None:
+            self.process.terminate()
+        self.master.destroy()
+
+
+def main():
+    root = tk.Tk()
+    gui = MurMurGUI(root)
+    root.protocol("WM_DELETE_WINDOW", gui.on_close)
+    root.mainloop()
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -30,3 +30,9 @@
 git clone https://github.com/younoulegeek/murmur-agent.git
 cd murmur-agent
 python main.py
+```
+
+## 🖱️ Simple GUI
+
+For a minimal graphical interface, run `python gui.py`.
+It provides Start/Stop buttons to control MurMur.


### PR DESCRIPTION
## Summary
- add a tiny Tkinter GUI (`gui.py`) that starts and stops MurMur
- document the GUI in both README files

## Testing
- `python gui.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684789baf3a883299181b830b6bea43f